### PR TITLE
Added a record of last curl request for tracing

### DIFF
--- a/src/tabs/api/client/ApiClient.php
+++ b/src/tabs/api/client/ApiClient.php
@@ -106,7 +106,7 @@ class ApiClient
      * 
      * @var string
      */
-    public $lastrequest;
+    protected $lastresponse;
 
     /**
      * Create a new Api Connection for use within the tabs php client
@@ -371,7 +371,15 @@ class ApiClient
             $this->getHmacParams($params)
         );
     }
-
+    
+    /**
+     * Fetch the last curl response
+     * 
+     * @return string
+     */
+    public function getLastResponse() {
+      return $this->lastresponse;
+    }
 
     // ------------------ Private Functions ---------------------//
 
@@ -519,8 +527,8 @@ class ApiClient
         $this->_setCurlOpt($follow);
 
         // Commit the curl request and return the response
-        $this->lastrequest = curl_exec($this->resource);
-        return $this->lastrequest;
+        $this->lastresponse = curl_exec($this->resource);
+        return $this->lastresponse;
     }
 
     /**


### PR DESCRIPTION
We would like to be able to log the raw responses from the API to help us debug some issues.  This patch will allow a client (of the client) to use:

```
\tabs\api\client\ApiClient::getApi()->getLastResponse()
```

to fetch the previous curl response.
