### PR TITLE
Allow api class to be extended

### DIFF
--- a/src/tabs/api/client/ApiClient.php
+++ b/src/tabs/api/client/ApiClient.php
@@ -123,7 +123,7 @@ class ApiClient
         $apiKey = '',
         $secret = ''
     ) {
-        self::$api = new ApiClient($apiUrl, $apiKey, $secret);
+        self::$api = new static($apiUrl, $apiKey, $secret);
         return self::$api;
     }
 
@@ -465,7 +465,7 @@ class ApiClient
      *
      * @return boolean or result
      */
-    private function _doRequest($apiFunc, $urlPath, $params)
+    protected function _doRequest($apiFunc, $urlPath, $params)
     {
         if (method_exists($this, $apiFunc)) {
             // Get parameters with hmac hash

--- a/src/tabs/api/utility/SagepayServer.php
+++ b/src/tabs/api/utility/SagepayServer.php
@@ -439,7 +439,7 @@ class SagepayServer
      * 
      * @return string
      */
-    private function _doPost($url, $data)
+    protected function _doPost($url, $data)
     {
         // Set a one-minute timeout for this script
         set_time_limit(60);


### PR DESCRIPTION
We would like to be able to log all communications from the API. The functions which handle both input and output should be protected to allow the logging. 

Also added late static bindings for the factory method to allow returning the new class over the tabs class
