### PR TITLE
Fixes 1st parameter must be an object in Customer

### DIFF
--- a/src/tabs/api/core/Customer.php
+++ b/src/tabs/api/core/Customer.php
@@ -115,7 +115,7 @@ class Customer Extends \tabs\api\core\Person
         $customer = \tabs\api\core\Customer::factory('', '');
         self::flattenNode($customer, $node);
 
-        if (property_exists($node, 'address')) {
+        if (is_object($node) && property_exists($node, 'address')) {
             $address = $customer->getAddress();
             self::setObjectProperties(
                 $address, 


### PR DESCRIPTION
Watchdog error:

 ID         :  1161109
 Date       :  16/Jan 13:44
 Type       :  php
 Severity   :  warning
 Message    :  Warning: First parameter must either be an object or the name of an existing class in
               tabs\api\core\Customer::createFromNode() (line 118 of
               /home/tobias/workspace/Cottaging/sites/fb/sites/all/libraries/tabs-api-client/src/tabs/api/core/Customer.php).
